### PR TITLE
Update README.md instructions to use go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The repository illustrates how to use the go [present](https://godoc.org/golang.org/x/tools/present) tool. To install the present tool run:
 
 ```
-go get golang.org/x/tools/cmd/present
+go install golang.org/x/tools/cmd/present@latest
 ```
 
 To run the present tool run:


### PR DESCRIPTION
'go get' is no longer supported for installing executables, use 'go install' with a version instead https://golang.org/doc/go-get-install-deprecation